### PR TITLE
Reset event stream when closing gRPC client

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 12, 14, 16 ]
+        node: [ 16 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -573,7 +573,7 @@ export class PuppetService extends Puppet {
      */
 
     /**
-     * Nick(202110):
+     * @hcfw007 Nick(202110):
      *  cancel() is needed when grpc connection breaks
      */
     if (!this.grpcClient) {

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -381,10 +381,9 @@ export class PuppetService extends Puppet {
       }
     }
 
+    this.stopGrpcStream()
     if (this.grpcClient) {
       try {
-        this.stopGrpcStream()
-
         await util.promisify(
           this.grpcClient.stop
             .bind(this.grpcClient)

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -415,9 +415,7 @@ export class PuppetService extends Puppet {
     log.verbose('PuppetService', 'startGrpcStream()')
 
     if (this.eventStream) {
-      this.stopGrpcStream()
-      log.warn('PuppetService', 'startGrpcStream() grpc stream is already started, will terminate and start new stream')
-      // throw new Error('event stream exists')
+      throw new Error('event stream exists')
     }
 
     let retry = MAX_GRPC_CONNECTION_RETRIES

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -573,8 +573,14 @@ export class PuppetService extends Puppet {
      *  destroy() will be enough to terminate a stream call.
      *  cancel() is not needed.
      */
-    // this.eventStream.cancel()
 
+    /**
+     * Nick(202110):
+     *  cancel() is needed when grpc connection breaks
+     */
+    if (!this.grpcClient) {
+      this.eventStream.cancel()
+    }
     this.eventStream.destroy()
     this.eventStream = undefined
   }

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -415,7 +415,9 @@ export class PuppetService extends Puppet {
     log.verbose('PuppetService', 'startGrpcStream()')
 
     if (this.eventStream) {
-      throw new Error('event stream exists')
+      this.stopGrpcStream()
+      log.warn('PuppetService', 'startGrpcStream() grpc stream is already started, will terminate and start new stream')
+      // throw new Error('event stream exists')
     }
 
     let retry = MAX_GRPC_CONNECTION_RETRIES

--- a/tests/grpc-stream.spec.ts
+++ b/tests/grpc-stream.spec.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env ts-node
+
+import {
+  test,
+  sinon,
+} from 'tstest'
+
+import {
+  PuppetOptions,
+} from 'wechaty-puppet'
+import {
+  PuppetMock,
+} from 'wechaty-puppet-mock'
+
+import {
+  PuppetService,
+  PuppetServer,
+  PuppetServerOptions,
+} from '../src/mod'
+
+test('Close eventStream when gRPC breaks', async (t) => {
+  const TOKEN = 'test_token'
+  const ENDPOINT = '0.0.0.0:8788'
+
+  const puppet = new PuppetMock()
+  const spyStart = sinon.spy(puppet, 'start')
+  /**
+   * Puppet Server
+   */
+  const serverOptions = {
+    endpoint: ENDPOINT,
+    puppet: puppet,
+    token: TOKEN,
+  } as PuppetServerOptions
+
+  const puppetServer = new PuppetServer(serverOptions)
+  await puppetServer.start()
+
+  /**
+   * Puppet Service Client
+   */
+  const puppetOptions = {
+    endpoint: ENDPOINT,
+    token: TOKEN,
+  } as PuppetOptions
+
+  const puppetService = (new PuppetService(puppetOptions)) as any
+  await puppetService.start()
+  t.ok(spyStart.called, 'should called the puppet server start() function')
+
+  // mock grpcClient break
+  puppetService.mockGrpcBreak = async function() {
+    await this.stopGrpcClient()
+  }
+
+  await puppetService.mockGrpcBreak()
+  await puppetService.stop()
+
+  // get eventStream status
+  puppetService.getEventStream = function () {
+    return this.eventStream
+  }
+  if (puppetService.getEventStream()) {
+    t.fail('event stream should be closed')
+  } else {
+    t.pass('event stream is closed')
+  }
+
+  await puppetServer.stop()
+})

--- a/tests/grpc-stream.spec.ts
+++ b/tests/grpc-stream.spec.ts
@@ -2,7 +2,7 @@
 
 /**
    * @hcfw007, https://wechaty.js.org/contributors/wang-nan/
-   * reloated issue: attempt to reconnect gRPC after disconnection
+   * related issue: attempt to reconnect gRPC after disconnection
    * Scenario: the watchdog tries to restart the service but failed due to the existence of eventstream
    * Caused by the grpcClient set to undefined (still working on why this happens) while eventstream still working
    * issue: #172, https://github.com/wechaty/puppet-service/issues/172

--- a/tests/grpc-stream.spec.ts
+++ b/tests/grpc-stream.spec.ts
@@ -1,5 +1,13 @@
 #!/usr/bin/env ts-node
 
+/**
+   * @hcfw007, https://wechaty.js.org/contributors/wang-nan/
+   * reloated issue: attempt to reconnect gRPC after disconnection
+   * Scenario: the watchdog tries to restart the service but failed due to the existence of eventstream
+   * Caused by the grpcClient set to undefined (still working on why this happens) while eventstream still working
+   * issue: #172, https://github.com/wechaty/puppet-service/issues/172
+   */
+
 import {
   test,
   sinon,

--- a/tests/grpc-stream.spec.ts
+++ b/tests/grpc-stream.spec.ts
@@ -49,7 +49,7 @@ test('Close eventStream when gRPC breaks', async (t) => {
   t.ok(spyStart.called, 'should called the puppet server start() function')
 
   // mock grpcClient break
-  puppetService.mockGrpcBreak = async function() {
+  puppetService.mockGrpcBreak = async function () {
     await this.stopGrpcClient()
   }
 


### PR DESCRIPTION
I put the call to stopGrpcStream() before check if grpcClient exists because:
1. grpcStream method will not fail even if stream does not exist
2. grpcStream might exist even if grpcClient does not

I try to destroy stream and then recreate instead of throw an error because:
1. I  think it's better to warn and recreate stream since the upper level bot does not have direct access to these private methods so to handle it properly.

Corresponding issue:   #172 