### PR TITLE
V0.22.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-service",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Puppet Service for Wechaty",
   "main": "dist/src/mod.js",
   "typings": "dist/src/mod.d.ts",


### PR DESCRIPTION
Did not bump version when creating last PR.
I thought it should be the privilege of the project owner.
Please publish this 0.22.3 cause we need this workaround urgently.