### PR TITLE
add draft issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEAT]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/workpro_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/workpro_bug_report.md
@@ -1,0 +1,33 @@
+---
+name: WorkPro Bug report
+about: Create a report to help us improve puppet-workpro
+title: "[BUG] "
+labels: workpro
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Info**
+ - Platform[eg Windows/Mac/Linux]: 
+ - Wechaty version: 
+ - Wechaty Puppet version: 
+ - WorkPro version: 
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
related to #218 

Current this is a draft design, comments are welcome. If we are happy with the current workpro issue template, I will add templates for all other types of service provider.

Also the github teams is needed, it would be better to get these team created and configured, so I can put them into these templates.